### PR TITLE
[Feat] 로그인 페이지 마크업 및 화면 전환 기능 구현

### DIFF
--- a/src/components/input.html
+++ b/src/components/input.html
@@ -9,7 +9,7 @@
     <link rel="preload" as="font" href="../../public/font/suit/SUIT-Variable.woff2" />
     <link rel="stylesheet" href="../../public/font/suit/SUIT-Variable.css" />
     <link rel="stylesheet" href="../../common/index.css" />
-    <link rel="stylesheet" href="./styles/input.css" />
+    <link rel="stylesheet" href="./style/input.css" />
   </head>
   <body>
     <a href="/index.html">메인 페이지 이동</a>

--- a/src/page/signin.html
+++ b/src/page/signin.html
@@ -9,13 +9,89 @@
     <link rel="shortcut icon" href="/favicon/favicon.ico" type="image/x-icon" />
     <link rel="icon" href="/favicon/favicon.svg" type="image/svg" />
     <link rel="preload" as="font" href="/font/woff2/PretendardVariable.woff2" crossorigin="anonymous" />
-    <link rel="stylesheet" as="style" href="/font/pretendardvariable.css" />
+    <link rel="stylesheet" href="/font/pretendardvariable.css" />
     <link rel="stylesheet" href="../common/index.css" />
-    <link rel="stylesheet" href="./style/itemlist.css" />
+    <link rel="stylesheet" href="./style/signin.css" />
   </head>
   <body>
-    <a href="../../index.html">메인 페이지 이동</a>
-    <br />
-    <h1>로그인 페이지</h1>
+    <a class="sr-only" href="../../index.html">메인 페이지 이동</a>
+    <h1 class="sr-only">로그인 페이지</h1>
+
+    <main class="login-wrapper">
+      <!-- 나이키 로고 -->
+      <svg width="76" height="60" viewBox="0 0 76 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M67.854 20L24.8132 38.2574C21.2297 39.7777 18.2152 40.5363 15.7859 40.5363C13.0525 40.5363 11.0613 39.5717 9.83849 37.6459C8.25274 35.1611 8.94589 31.1656 11.6662 26.9479C13.2814 24.4826 15.3347 22.22 17.3356 20.0556C16.8648 20.8207 12.7092 27.7358 17.2539 30.9923C18.153 31.6463 19.4314 31.9667 21.0041 31.9667C22.2662 31.9667 23.7146 31.7607 25.3069 31.3455L67.854 20Z" fill="#111111" />
+      </svg>
+      <!-- 이메일 입력 화면 -->
+      <section id="email-section">
+        <div class="login-logo" aria-hidden="true"></div>
+        <h2 class="sr-only">로그인</h2>
+        <p class="login-title">가입 또는 로그인을 위해 이메일을 입력하세요.</p>
+        <form class="login-form">
+          <div class="input-group">
+            <label for="email" class="input-label sr-only">이메일</label>
+            <div class="input-wrapper">
+              <input type="email" id="email" name="email" class="input-field" placeholder="이메일" required />
+            </div>
+          </div>
+          <p class="login-description">계속 진행하면 나이키의 <a href="#" class="link">개인정보 처리방침</a> 및 <a href="#" class="link">이용약관</a>에 동의하게 됩니다.</p>
+          <button type="button" class="button fill small" id="continue-btn">계속</button>
+        </form>
+      </section>
+
+      <!-- 비밀번호 입력 화면 -->
+      <section id="password-section" style="display: none">
+        <h2 class="sr-only">비밀번호</h2>
+        <p class="login-title">비밀번호를 입력하세요.</p>
+        <p id="email-display" class="login-description email-display">example@email.com</p>
+
+        <form class="login-form" id="password-form">
+          <div class="input-group">
+            <label for="password" class="input-label sr-only">비밀번호</label>
+            <div class="input-wrapper">
+              <input type="password" id="password" name="password" class="input-field" placeholder="비밀번호" required />
+            </div>
+          </div>
+          <a href="#" class="link" style="font-size: var(--text-xs); color: var(--gray)">비밀번호 찾기</a>
+
+          <div style="display: flex; justify-content: space-between; gap: 1rem">
+            <button type="button" class="button" id="back-btn" style="background: white; color: black; border: 1px solid var(--black)">이전</button>
+            <button type="submit" class="button fill small">로그인</button>
+          </div>
+        </form>
+      </section>
+
+      <script>
+        const continueBtn = document.getElementById('continue-btn');
+        const emailInput = document.getElementById('email');
+        const emailSection = document.getElementById('email-section');
+        const passwordSection = document.getElementById('password-section');
+        const emailDisplay = document.getElementById('email-display');
+        const backBtn = document.getElementById('back-btn');
+        const passwordForm = document.getElementById('password-form');
+
+        continueBtn.addEventListener('click', () => {
+          const email = emailInput.value.trim();
+          if (!email.includes('@')) {
+            alert('올바른 이메일 형식을 입력하세요.');
+            return;
+          }
+
+          emailDisplay.textContent = email;
+          emailSection.style.display = 'none';
+          passwordSection.style.display = 'block';
+        });
+
+        backBtn.addEventListener('click', () => {
+          passwordSection.style.display = 'none';
+          emailSection.style.display = 'block';
+        });
+
+        passwordForm.addEventListener('submit', (e) => {
+          e.preventDefault();
+          alert('로그인 처리 예정입니다.');
+        });
+      </script>
+    </main>
   </body>
 </html>

--- a/src/page/style/signin.css
+++ b/src/page/style/signin.css
@@ -1,0 +1,127 @@
+.login-wrapper {
+  inline-size: 100%;
+  max-inline-size: 28rem; /* 448px */
+  margin-inline: auto;
+  padding-block: 2.5rem;
+  padding-inline: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Pretendard', sans-serif;
+  gap: 2rem;
+}
+
+.login-logo svg {
+  inline-size: 3rem;
+  block-size: auto;
+}
+
+.login-title {
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--black);
+  line-height: 1.5;
+}
+
+.login-form {
+  inline-size: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.input-wrapper {
+  border: 1px solid var(--light-gray);
+  border-radius: 0.25rem;
+  background-color: var(--white);
+  padding-block: 0.625rem;
+  padding-inline: 1rem;
+}
+
+.input-field {
+  inline-size: 100%;
+  border: none;
+  background: none;
+  font-size: var(--text-base);
+  color: var(--black);
+  outline: none;
+}
+
+.login-description {
+  font-size: var(--text-xs);
+  color: var(--gray);
+  line-height: 1.6;
+}
+
+.login-description .link {
+  text-decoration: underline;
+  color: var(--black);
+}
+
+.button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  inline-size: 7.125rem;
+  block-size: 2.5rem;
+  padding-inline: 1.875rem;
+  padding-block: 0.75rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  line-height: 1;
+  text-align: center;
+  color: var(--white);
+  background-color: var(--black);
+  border: none;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.button:hover {
+  opacity: 0.8;
+}
+
+.button:focus-visible {
+  outline: 0.1875rem solid var(--blue);
+}
+
+/* ✅ 모바일 (640px 이하, 선택적으로 커스터마이징 필요할 때만) */
+@media (max-width: calc(var(--breakpoint-sm) - 0.0625rem)) {
+  .login-wrapper {
+    padding-inline: 1rem;
+  }
+
+  .button.fill.small {
+    font-size: var(--text-sm);
+    padding-block: 0.625rem;
+    padding-inline: 1.5rem;
+  }
+}
+
+/* ✅ 태블릿 이상 (640px 이상) */
+@media (min-width: var(--breakpoint-sm)) {
+  .login-title {
+    font-size: var(--text-xl);
+  }
+
+  .button.fill.small {
+    font-size: var(--text-base);
+    padding-inline: 2.5rem;
+  }
+}
+
+/* ✅ 데스크탑 이상 (1024px 이상) */
+@media (min-width: var(--breakpoint-lg)) {
+  .login-wrapper {
+    padding-block: 4rem;
+    padding-inline: 2rem;
+  }
+
+  .login-title {
+    font-size: var(--text-2xl);
+  }
+
+  .login-form {
+    gap: 1.5rem;
+  }
+}


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코딩 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버튼 클릭 시 화면 전환 등 기본 동작 확인)

### PR 상세
- 로그인 페이지의 기본 마크업 구성 (이메일 → 비밀번호 입력 UI)
- `continue` 버튼 클릭 시 이메일 검증 후 비밀번호 입력 화면으로 전환되도록 JS 구현
- `back` 버튼 클릭 시 다시 이메일 입력 화면으로 돌아오는 로직 추가
- 나이키 로고는 공통 영역으로 분리하여 두 화면에서 모두 유지되도록 수정
- `.sr-only`, `aria-hidden` 등을 활용한 접근성 반영

## 이슈
resolves #44 
